### PR TITLE
add --config-dir support to shellclear cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ USAGE:
     shellclear [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
-    -h, --help           Print help information
-        --init-shell     Show sensitive findings summary for MOTD
-        --log <LEVEL>    Set logging level [default: INFO] [possible values: OFF, TRACE, DEBUG,
-                         INFO, WARN, ERROR]
-        --no-banner      Don't show the banner
-    -V, --version        Print version information
+        --config-dir <CFG_DIR_PATH>    Set configuration directory path
+    -h, --help                         Print help information
+        --init-shell                   Show sensitive findings summary for MOTD
+        --log <LEVEL>                  Set logging level [default: INFO] [possible values: OFF,
+                                       TRACE, DEBUG, INFO, WARN, ERROR]
+        --no-banner                    Don't show the banner
+    -V, --version                      Print version information
+
 
 SUBCOMMANDS:
     config     Create custom configuration

--- a/shellclear/src/bin/cmd/default.rs
+++ b/shellclear/src/bin/cmd/default.rs
@@ -36,4 +36,11 @@ pub fn command() -> Command<'static> {
                 .help("Show sensitive findings summary for MOTD")
                 .takes_value(false),
         )
+        .arg(
+            Arg::new("config-dir")
+                .long("config-dir")
+                .help("Set configuration directory path")
+                .value_name("CFG_DIR_PATH")
+                .takes_value(true),
+        )
 }

--- a/shellclear/src/bin/shellclear.rs
+++ b/shellclear/src/bin/shellclear.rs
@@ -28,7 +28,7 @@ fn main() {
     );
     env_logger::init_from_env(env);
 
-    let config = Config::default();
+    let config = Config::from(matches.value_of("config-dir"));
     // create app config to store state data
     let shells_context = match init() {
         Ok(s) => s,

--- a/shellclear/src/config.rs
+++ b/shellclear/src/config.rs
@@ -28,6 +28,17 @@ impl Default for Config {
     }
 }
 
+impl From<Option<&str>> for Config {
+    fn from(config_dir_path_option: Option<&str>) -> Self {
+       match config_dir_path_option {
+           None => Self::default(),
+           Some(cfg_dir_path) => {
+            Self::with_custom_path(PathBuf::from(cfg_dir_path))
+           },
+       }
+    }
+}
+
 impl Config {
     #[allow(dead_code)]
     #[must_use]

--- a/shellclear/src/config.rs
+++ b/shellclear/src/config.rs
@@ -29,13 +29,11 @@ impl Default for Config {
 }
 
 impl From<Option<&str>> for Config {
-    fn from(config_dir_path_option: Option<&str>) -> Self {
-       match config_dir_path_option {
-           None => Self::default(),
-           Some(cfg_dir_path) => {
-            Self::with_custom_path(PathBuf::from(cfg_dir_path))
-           },
-       }
+    fn from(config_dir: Option<&str>) -> Self {
+        match config_dir {
+            None => Self::default(),
+            Some(cfg_dir_path) => Self::with_custom_path(PathBuf::from(cfg_dir_path)),
+        }
     }
 }
 

--- a/shellclear/src/config.rs
+++ b/shellclear/src/config.rs
@@ -160,17 +160,54 @@ impl Config {
 
 #[cfg(test)]
 mod test_config {
-    use crate::config::IGNORES_SENSITIVE_PATTERN_TEMPLATE;
+    use crate::{config::IGNORES_SENSITIVE_PATTERN_TEMPLATE, data::ROOT_APP_FOLDER};
 
-    use super::{Config, SENSITIVE_PATTERN_TEMPLATE};
+    use super::{Config, CONFIG_IGNORES, CONFIG_SENSITIVE_PATTERNS, SENSITIVE_PATTERN_TEMPLATE};
     use insta::assert_debug_snapshot;
-    use std::fs;
+    use std::{fs, path::PathBuf};
     use tempdir::TempDir;
 
     fn new_config(temp_dir: &TempDir) -> Config {
         let path = temp_dir.path().join("app");
         fs::create_dir_all(&path).unwrap();
         Config::with_custom_path(path)
+    }
+
+    #[test]
+    fn new_config_from_string() {
+        let cfg_dir = "home/user1";
+        let path = PathBuf::from(cfg_dir);
+        let config = Config::from(path.as_os_str().to_str());
+        assert_debug_snapshot!(
+            config.app_path == PathBuf::from(format!("{}/{}", cfg_dir, ROOT_APP_FOLDER))
+        );
+        assert_debug_snapshot!(
+            config.ignore_sensitive_path
+                == PathBuf::from(format!(
+                    "{}/{}/{}",
+                    cfg_dir, ROOT_APP_FOLDER, CONFIG_IGNORES
+                ))
+        );
+        assert_debug_snapshot!(
+            config.sensitive_commands_path
+                == PathBuf::from(format!(
+                    "{}/{}/{}",
+                    cfg_dir, ROOT_APP_FOLDER, CONFIG_SENSITIVE_PATTERNS
+                ))
+        );
+    }
+
+    #[test]
+    fn new_config_from_none_use_default() {
+        let config = Config::from(None);
+        let default_config = Config::default();
+        assert_debug_snapshot!(config.app_path == default_config.app_path);
+        assert_debug_snapshot!(
+            config.ignore_sensitive_path == default_config.ignore_sensitive_path
+        );
+        assert_debug_snapshot!(
+            config.sensitive_commands_path == default_config.sensitive_commands_path
+        );
     }
 
     #[test]

--- a/shellclear/src/dialog.rs
+++ b/shellclear/src/dialog.rs
@@ -61,6 +61,6 @@ pub fn multi_choice(
 
     match answer.as_list_items() {
         Some(list) => Ok(list.iter().map(|s| s.text.to_string()).collect::<Vec<_>>()),
-        None => return Err(anyhow!("could not get selected list")),
+        None => Err(anyhow!("could not get selected list")),
     }
 }

--- a/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_none_use_default-2.snap
+++ b/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_none_use_default-2.snap
@@ -1,0 +1,5 @@
+---
+source: shellclear/src/config.rs
+expression: config.ignore_sensitive_path == default_config.ignore_sensitive_path
+---
+true

--- a/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_none_use_default-3.snap
+++ b/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_none_use_default-3.snap
@@ -1,0 +1,5 @@
+---
+source: shellclear/src/config.rs
+expression: config.sensitive_commands_path == default_config.sensitive_commands_path
+---
+true

--- a/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_none_use_default.snap
+++ b/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_none_use_default.snap
@@ -1,0 +1,5 @@
+---
+source: shellclear/src/config.rs
+expression: config.app_path == default_config.app_path
+---
+true

--- a/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_string-2.snap
+++ b/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_string-2.snap
@@ -1,0 +1,5 @@
+---
+source: shellclear/src/config.rs
+expression: "config.ignore_sensitive_path ==\n    PathBuf::from(format!(\"{}/{}/{}\", cfg_dir, ROOT_APP_FOLDER,\n            CONFIG_IGNORES))"
+---
+true

--- a/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_string-3.snap
+++ b/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_string-3.snap
@@ -1,0 +1,5 @@
+---
+source: shellclear/src/config.rs
+expression: "config.sensitive_commands_path ==\n    PathBuf::from(format!(\"{}/{}/{}\", cfg_dir, ROOT_APP_FOLDER,\n            CONFIG_SENSITIVE_PATTERNS))"
+---
+true

--- a/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_string.snap
+++ b/shellclear/src/snapshots/shellclear__config__test_config__new_config_from_string.snap
@@ -1,0 +1,5 @@
+---
+source: shellclear/src/config.rs
+expression: "config.app_path == PathBuf::from(format!(\"{}/{}\", cfg_dir, ROOT_APP_FOLDER))"
+---
+true


### PR DESCRIPTION
I am not sure if this exists or is unnecessary but I couldn't figure out how to set the configuration files directory through the CLI and I want to save it in a different location than `homedir`.
So I decided to add this to the code, let me know if that works out for you.
Thanks.