### PR TITLE
Issue #64: Add tests for curl, URL basic-auth, and wget

### DIFF
--- a/shellclear/src/sensitive-patterns.yaml
+++ b/shellclear/src/sensitive-patterns.yaml
@@ -10,6 +10,14 @@
   test: (?i)(aws_access_key_id|aws_secret_access_key)=([0-9a-zA-Z/+]{20,40})
   secret_group: 2
   id: aws_cred
+- name: cURL Basic Authentication
+  test: (?i:authorization):(?:.*)(?i:Basic)(.*)(\"|\'|\x60|\$\()
+  secret_group: 2
+  id: curl_basic_auth
+- name: cURL User Login
+  test: curl.*(?:-u|--user) ([^ ]*)
+  secret_group: 1
+  id: curl_user_login
 - name: GitHub Env Token
   test: GITHUB_TOKEN=([0-9a-zA-Z/+]{0,100})
   secret_group: 1

--- a/shellclear/src/sensitive-patterns.yaml
+++ b/shellclear/src/sensitive-patterns.yaml
@@ -102,6 +102,10 @@
   test: SK[0-9a-fA-F]{32}
   secret_group: 0
   id: twilio_api_key
+- name: URL Basic Auth
+  test: (([A-Za-z]*:(?:\/\/)?)([-;:&=\+\$,\w]+)@[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w\-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?
+  secret_group: 3
+  id: url_basic_auth
 - name: GCP API Key
   test: (?i)\b(AIza[0-9A-Za-z\\-_]{35})(?:['|"|\n|\r|\s|\x60]|$)
   secret_group: 0

--- a/shellclear/src/sensitive-patterns.yaml
+++ b/shellclear/src/sensitive-patterns.yaml
@@ -14,10 +14,10 @@
   test: (?i:authorization):(?:.*)(?i:Basic).(.*)("|'|\x60|\$\()
   secret_group: 1
   id: curl_basic_auth
-#- name: cURL User Login
-#  test: curl.*(?:-u|--user)(?:[ =])([^ ]*)
-#  secret_group: 1
-#  id: curl_user_login
+- name: cURL User Login
+  test: curl.*(?:-u|--user)(?:[ =])([^ ]*)
+  secret_group: 1
+  id: curl_user_login
 - name: GitHub Env Token
   test: GITHUB_TOKEN=([0-9a-zA-Z/+]{0,100})
   secret_group: 1
@@ -102,10 +102,10 @@
   test: SK[0-9a-fA-F]{32}
   secret_group: 0
   id: twilio_api_key
-#- name: URL Basic Auth
-#  test: (([A-Za-z]*:(?://)?)([-;:&=\+\$,\w]+)@[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:/[\+~%/.\w\-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?
-#  secret_group: 3
-#  id: url_basic_auth
+- name: URL Basic Auth
+  test: (([A-Za-z]*:(?://)?)([-;:&=\+\$,\w]+)@[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:/[\+~%/.\w\-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?
+  secret_group: 3
+  id: url_basic_auth
 - name: GCP API Key
   test: (?i)\b(AIza[0-9A-Za-z\\-_]{35})(?:['|"|\n|\r|\s|\x60]|$)
   secret_group: 0
@@ -126,10 +126,10 @@
   test: (?i)twitter(.{0,20})?[''"]([0-9a-z]{18,25})[''"]
   secret_group: 2
   id: twitter_clientid
-#- name: Wget Username Password Authentication
-#  test: wget(?:.*)--(?:ftp-|http-)?(?:password|user)[ =]([^ ]*)
-#  secret_group: 1
-#  id: wget_user_login
+- name: Wget Username Password Authentication
+  test: wget(?:.*)--(?:ftp-|http-)?(?:password|user)[ =]([^ ]*)
+  secret_group: 1
+  id: wget_user_login
 - name: LinkedIn Secret Key
   test: (?i)linkedin(.{0,20})?(?-i)[''"]([0-9a-zA-Z]{12,16})[''"]
   secret_group: 2

--- a/shellclear/src/sensitive-patterns.yaml
+++ b/shellclear/src/sensitive-patterns.yaml
@@ -126,6 +126,10 @@
   test: (?i)twitter(.{0,20})?[''"]([0-9a-z]{18,25})[''"]
   secret_group: 2
   id: twitter_clientid
+- name: Wget Username Password Authentication
+  test: wget(?:.*)--(?:ftp-|http-)?(?:password|user)
+  secret_group: 0
+  id: wget_user_login
 - name: LinkedIn Secret Key
   test: (?i)linkedin(.{0,20})?(?-i)[''"]([0-9a-zA-Z]{12,16})[''"]
   secret_group: 2

--- a/shellclear/src/sensitive-patterns.yaml
+++ b/shellclear/src/sensitive-patterns.yaml
@@ -12,12 +12,12 @@
   id: aws_cred
 - name: cURL Basic Authentication
   test: (?i:authorization):(?:.*)(?i:Basic).(.*)("|'|\x60|\$\()
-  secret_group: 2
-  id: curl_basic_auth
-- name: cURL User Login
-  test: curl.*(?:-u|--user)(?:[ =])([^ ]*)
   secret_group: 1
-  id: curl_user_login
+  id: curl_basic_auth
+#- name: cURL User Login
+#  test: curl.*(?:-u|--user)(?:[ =])([^ ]*)
+#  secret_group: 1
+#  id: curl_user_login
 - name: GitHub Env Token
   test: GITHUB_TOKEN=([0-9a-zA-Z/+]{0,100})
   secret_group: 1
@@ -102,10 +102,10 @@
   test: SK[0-9a-fA-F]{32}
   secret_group: 0
   id: twilio_api_key
-- name: URL Basic Auth
-  test: (([A-Za-z]*:(?://)?)([-;:&=\+\$,\w]+)@[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:/[\+~%/.\w\-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?
-  secret_group: 3
-  id: url_basic_auth
+#- name: URL Basic Auth
+#  test: (([A-Za-z]*:(?://)?)([-;:&=\+\$,\w]+)@[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:/[\+~%/.\w\-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?
+#  secret_group: 3
+#  id: url_basic_auth
 - name: GCP API Key
   test: (?i)\b(AIza[0-9A-Za-z\\-_]{35})(?:['|"|\n|\r|\s|\x60]|$)
   secret_group: 0
@@ -126,10 +126,10 @@
   test: (?i)twitter(.{0,20})?[''"]([0-9a-z]{18,25})[''"]
   secret_group: 2
   id: twitter_clientid
-- name: Wget Username Password Authentication
-  test: wget(?:.*)--(?:ftp-|http-)?(?:password|user)
-  secret_group: 0
-  id: wget_user_login
+#- name: Wget Username Password Authentication
+#  test: wget(?:.*)--(?:ftp-|http-)?(?:password|user)[ =]([^ ]*)
+#  secret_group: 1
+#  id: wget_user_login
 - name: LinkedIn Secret Key
   test: (?i)linkedin(.{0,20})?(?-i)[''"]([0-9a-zA-Z]{12,16})[''"]
   secret_group: 2

--- a/shellclear/src/sensitive-patterns.yaml
+++ b/shellclear/src/sensitive-patterns.yaml
@@ -11,11 +11,11 @@
   secret_group: 2
   id: aws_cred
 - name: cURL Basic Authentication
-  test: (?i:authorization):(?:.*)(?i:Basic)(.*)(\"|\'|\x60|\$\()
+  test: (?i:authorization):(?:.*)(?i:Basic).(.*)("|'|\x60|\$\()
   secret_group: 2
   id: curl_basic_auth
 - name: cURL User Login
-  test: curl.*(?:-u|--user) ([^ ]*)
+  test: curl.*(?:-u|--user)(?:[ =])([^ ]*)
   secret_group: 1
   id: curl_user_login
 - name: GitHub Env Token
@@ -103,7 +103,7 @@
   secret_group: 0
   id: twilio_api_key
 - name: URL Basic Auth
-  test: (([A-Za-z]*:(?:\/\/)?)([-;:&=\+\$,\w]+)@[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w\-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?
+  test: (([A-Za-z]*:(?://)?)([-;:&=\+\$,\w]+)@[A-Za-z0-9.-]+(:[0-9]+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:/[\+~%/.\w\-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?
   secret_group: 3
   id: url_basic_auth
 - name: GCP API Key

--- a/shellclear/tests/snapshots/sensitive_patterns_test__curl_basic_auth.snap
+++ b/shellclear/tests/snapshots/sensitive_patterns_test__curl_basic_auth.snap
@@ -1,0 +1,30 @@
+---
+source: shellclear/tests/sensitive-patterns_test.rs
+expression: results
+---
+[
+    TestPatternResult {
+        name: "detect curl -H Authorization Basic [base64_encoded_login]",
+        test: "curl -X POST -H 'Authorization: Basic YmFzZTY0OnBhc3N3b3JkCg==' https://priv/",
+        detect: "YmFzZTY0OnBhc3N3b3JkCg==",
+        expected: "YmFzZTY0OnBhc3N3b3JkCg==",
+    },
+    TestPatternResult {
+        name: "detect curl header authorization basic with reading from a file",
+        test: "curl --header 'authorization: basic `cat /tmp/secret`' https://priv/",
+        detect: "`cat /tmp/secret`",
+        expected: "`cat /tmp/secret`",
+    },
+    TestPatternResult {
+        name: "detect curl header authorization basic with reading from a file alternative method",
+        test: "curl --header 'authorization: basic $(cat /tmp/secret)' https://priv/",
+        detect: "$(cat /tmp/secret)",
+        expected: "$(cat /tmp/secret)",
+    },
+    TestPatternResult {
+        name: "detect curl -H authorization with secret environment variable",
+        test: "curl -H 'Authorization: Basic $SECRET_VAR' https://priv/",
+        detect: "$SECRET_VAR",
+        expected: "$SECRET_VAR",
+    },
+]

--- a/shellclear/tests/snapshots/sensitive_patterns_test__curl_user_login.snap
+++ b/shellclear/tests/snapshots/sensitive_patterns_test__curl_user_login.snap
@@ -1,0 +1,18 @@
+---
+source: shellclear/tests/sensitive-patterns_test.rs
+expression: results
+---
+[
+    TestPatternResult {
+        name: "detect curl -u user:pass",
+        test: "curl -u user:pass https://priv/",
+        detect: "user:pass",
+        expected: "user:pass",
+    },
+    TestPatternResult {
+        name: "detect curl --user user:pass",
+        test: "curl --user user:pass https://priv/",
+        detect: "user:pass",
+        expected: "user:pass",
+    },
+]

--- a/shellclear/tests/snapshots/sensitive_patterns_test__url_basic_auth.snap
+++ b/shellclear/tests/snapshots/sensitive_patterns_test__url_basic_auth.snap
@@ -1,0 +1,12 @@
+---
+source: shellclear/tests/sensitive-patterns_test.rs
+expression: results
+---
+[
+    TestPatternResult {
+        name: "detect schema://user:pass@domain.tld/",
+        test: "./do_something https://username:password@supersecure.service/",
+        detect: "username:password",
+        expected: "username:password",
+    },
+]

--- a/shellclear/tests/snapshots/sensitive_patterns_test__wget_user_login.snap
+++ b/shellclear/tests/snapshots/sensitive_patterns_test__wget_user_login.snap
@@ -1,0 +1,24 @@
+---
+source: shellclear/tests/sensitive-patterns_test.rs
+expression: results
+---
+[
+    TestPatternResult {
+        name: "detect wget ftp login",
+        test: "wget --ftp-user username --ftp-password password ftp.website.com",
+        detect: "password",
+        expected: "password",
+    },
+    TestPatternResult {
+        name: "detect wget http login",
+        test: "wget --http-user username --http-password password http.website.com",
+        detect: "password",
+        expected: "password",
+    },
+    TestPatternResult {
+        name: "detect wget basic login",
+        test: "wget -user username --password password website.com",
+        detect: "password",
+        expected: "password",
+    },
+]

--- a/shellclear/tests/suites_sensitive_patterns/curl_basic_auth.yaml
+++ b/shellclear/tests/suites_sensitive_patterns/curl_basic_auth.yaml
@@ -12,4 +12,4 @@
 
 - name: detect curl -H authorization with secret environment variable
   test: "curl -H 'Authorization: Basic $SECRET_VAR' https://priv/"
-  expected: YmFzZTY0OnBhc3N3b3JkCg==
+  expected: "$SECRET_VAR"

--- a/shellclear/tests/suites_sensitive_patterns/curl_basic_auth.yaml
+++ b/shellclear/tests/suites_sensitive_patterns/curl_basic_auth.yaml
@@ -1,0 +1,15 @@
+- name: detect curl -H Authorization Basic [base64_encoded_login]
+  test: curl -X POST -H 'Authorization: Basic YmFzZTY0OnBhc3N3b3JkCg==' https://priv/
+  result: YmFzZTY0OnBhc3N3b3JkCg==
+
+- name: detect curl --header authorization: basic with reading from a file
+  test: curl --header 'authorization: basic `cat /tmp/secret`' https://priv/
+  result: YmFzZTY0OnBhc3N3b3JkCg==
+
+- name: detect curl --header authorization: basic with reading from a file alternative method
+  test: curl --header 'authorization: basic $(cat /tmp/secret)' https://priv/
+  result: YmFzZTY0OnBhc3N3b3JkCg==
+
+- name: detect curl -H authorization with secret environment variable
+  test: curl -H 'Authorization: Basic $SECRET_VAR' https://priv/
+  result: YmFzZTY0OnBhc3N3b3JkCg==

--- a/shellclear/tests/suites_sensitive_patterns/curl_basic_auth.yaml
+++ b/shellclear/tests/suites_sensitive_patterns/curl_basic_auth.yaml
@@ -1,15 +1,15 @@
 - name: detect curl -H Authorization Basic [base64_encoded_login]
-  test: curl -X POST -H 'Authorization: Basic YmFzZTY0OnBhc3N3b3JkCg==' https://priv/
-  result: YmFzZTY0OnBhc3N3b3JkCg==
+  test: "curl -X POST -H 'Authorization: Basic YmFzZTY0OnBhc3N3b3JkCg==' https://priv/"
+  expected: YmFzZTY0OnBhc3N3b3JkCg==
 
-- name: detect curl --header authorization: basic with reading from a file
-  test: curl --header 'authorization: basic `cat /tmp/secret`' https://priv/
-  result: YmFzZTY0OnBhc3N3b3JkCg==
+- name: detect curl header authorization basic with reading from a file
+  test: "curl --header 'authorization: basic `cat /tmp/secret`' https://priv/"
+  expected: "`cat /tmp/secret`"
 
-- name: detect curl --header authorization: basic with reading from a file alternative method
-  test: curl --header 'authorization: basic $(cat /tmp/secret)' https://priv/
-  result: YmFzZTY0OnBhc3N3b3JkCg==
+- name: detect curl header authorization basic with reading from a file alternative method
+  test: "curl --header 'authorization: basic $(cat /tmp/secret)' https://priv/"
+  expected: "$(cat /tmp/secret)"
 
 - name: detect curl -H authorization with secret environment variable
-  test: curl -H 'Authorization: Basic $SECRET_VAR' https://priv/
-  result: YmFzZTY0OnBhc3N3b3JkCg==
+  test: "curl -H 'Authorization: Basic $SECRET_VAR' https://priv/"
+  expected: YmFzZTY0OnBhc3N3b3JkCg==

--- a/shellclear/tests/suites_sensitive_patterns/curl_user_login.yaml
+++ b/shellclear/tests/suites_sensitive_patterns/curl_user_login.yaml
@@ -1,7 +1,6 @@
 - name: detect curl -u user:pass
   test: curl -u user:pass https://priv/
-  result: user:pass
-
+  expected: user:pass
 - name: detect curl --user user:pass
   test: curl --user user:pass https://priv/
-  result: user:pass
+  expected: user:pass

--- a/shellclear/tests/suites_sensitive_patterns/curl_user_login.yaml
+++ b/shellclear/tests/suites_sensitive_patterns/curl_user_login.yaml
@@ -1,0 +1,7 @@
+- name: detect curl -u user:pass
+  test: curl -u user:pass https://priv/
+  result: user:pass
+
+- name: detect curl --user user:pass
+  test: curl --user user:pass https://priv/
+  result: user:pass

--- a/shellclear/tests/suites_sensitive_patterns/url_basic_auth.yaml
+++ b/shellclear/tests/suites_sensitive_patterns/url_basic_auth.yaml
@@ -1,3 +1,3 @@
 - name: detect schema://user:pass@domain.tld/
   test: ./do_something https://username:password@supersecure.service/
-  result: username:password
+  expected: username:password

--- a/shellclear/tests/suites_sensitive_patterns/url_basic_auth.yaml
+++ b/shellclear/tests/suites_sensitive_patterns/url_basic_auth.yaml
@@ -1,0 +1,3 @@
+- name: detect schema://user:pass@domain.tld/
+  test: ./do_something https://username:password@supersecure.service/
+  result: username:password

--- a/shellclear/tests/suites_sensitive_patterns/wget_user_login.yaml
+++ b/shellclear/tests/suites_sensitive_patterns/wget_user_login.yaml
@@ -1,11 +1,9 @@
-name: detect wget ftp login
-test: wget --ftp-user username --ftp-password password ftp.website.com
-result: password
-
-name: detect wget http login
-test: wget --http-user username --http-password password http.website.com
-result: password
-
-name: detect wget basic login
-test: wget -user username --password password website.com
-result: password
+- name: detect wget ftp login
+  test: wget --ftp-user username --ftp-password password ftp.website.com
+  expected: password
+- name: detect wget http login
+  test: wget --http-user username --http-password password http.website.com
+  expected: password
+- name: detect wget basic login
+  test: wget -user username --password password website.com
+  expected: password

--- a/shellclear/tests/suites_sensitive_patterns/wget_user_login.yaml
+++ b/shellclear/tests/suites_sensitive_patterns/wget_user_login.yaml
@@ -1,0 +1,11 @@
+name: detect wget ftp login
+test: wget --ftp-user username --ftp-password password ftp.website.com
+result: password
+
+name: detect wget http login
+test: wget --http-user username --http-password password http.website.com
+result: password
+
+name: detect wget basic login
+test: wget -user username --password password website.com
+result: password


### PR DESCRIPTION
cURL: The -u flag and the 'Authorization' header may contain plaintext or base64-encoded secrets.
URL: A URL may contain a login combination.
wget: various flags pass around username and passsword combinations.

Fixes #64 (and more).